### PR TITLE
Switch from `nose` to `pytest`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,5 @@ jobs:
 
       - name: Run tests
         run: make test
+
+      - uses: codecov/codecov-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,9 @@ FROM python:3.7
 WORKDIR /sherlock
 
 # Memcached
-RUN apt-get update -y && apt-get install -y libmemcached-dev
-RUN pip install pytz coverage ipython ipdb
+RUN apt-get update -y && apt-get install -y libmemcached-dev gcc
+RUN pip install pytz ipython ipdb
+
+COPY requirements-ci.txt /sherlock/requirements-ci.txt
+RUN pip install -r /sherlock/requirements-ci.txt && \
+    rm /sherlock/requirements-ci.txt

--- a/README.rst
+++ b/README.rst
@@ -8,10 +8,11 @@ synchronization.
 
 |Build Status| |Coverage Status|
 
-.. |Build Status| image:: https://travis-ci.org/vaidik/sherlock.png
-   :target: https://travis-ci.org/vaidik/sherlock/
-.. |Coverage Status| image:: https://coveralls.io/repos/vaidik/incoming/badge.png
-   :target: https://coveralls.io/r/vaidik/incoming
+.. |Build Status| image:: https://github.com/py-sherlock/sherlock/actions/workflows/ci.yml/badge.svg
+   :target: https://github.com/py-sherlock/sherlock/actions?query=workflow%3ACI/CD
+
+.. |Coverage Status| image:: https://codecov.io/gh/py-sherlock/sherlock/branch/master/graph/badge.svg?token=QJXCZVSAEF
+ :target: https://codecov.io/gh/py-sherlock/sherlock
 
 Overview
 --------
@@ -33,7 +34,7 @@ backends that are not supported.
 Features
 ++++++++
 
-* API similar to standard library's `threading.Lock`. 
+* API similar to standard library's `threading.Lock`.
 * Support for With statement, to cleanly acquire and release locks.
 * Backend agnostic: supports `Redis`_, `Memcached`_ and `Etcd`_ as choice of
   backends.
@@ -131,7 +132,7 @@ Blocking and Non-blocking API
     # acquire non-blocking lock
     lock1 = Lock('my_lock')
     lock2 = Lock('my_lock')
-    
+
     # successfully acquire lock1
     lock1.acquire()
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,11 +6,11 @@ sherlock:
     - memcached:memcached
   volumes:
     - .:/sherlock:Z
-  entrypoint: coverage run --source=sherlock setup.py test
+  entrypoint: bash -c 'pip install -e . && coverage run --source=sherlock -m pytest tests/'
   stdin_open: true
   tty: true
 etcd:
-  image: vaidik/etcd
+  image: quay.io/coreos/etcd
   command: |
     etcd --listen-client-urls="http://0.0.0.0:2379,http://0.0.0.0:4001" --advertise-client-urls="http://0.0.0.0:2379,http://0.0.0.0:4001"
   ports:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,7 +6,8 @@ sherlock:
     - memcached:memcached
   volumes:
     - .:/sherlock:Z
-  entrypoint: bash -c 'pip install -e . && coverage run --source=sherlock -m pytest tests/'
+  entrypoint: |
+    bash -c 'pip install -e . &&  pytest --cov-report term --cov-report xml --cov=sherlock tests/'
   stdin_open: true
   tty: true
 etcd:

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,0 +1,3 @@
+coverage
+pytest
+wheel

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,3 +1,3 @@
-coverage
 pytest
+pytest-cov
 wheel

--- a/setup.py
+++ b/setup.py
@@ -38,9 +38,4 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
     ],
-    test_suite='nose.collector',
-    tests_require=[
-        'nose',
-        'mock',
-    ]
 )

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -6,8 +6,7 @@ import etcd
 import redis
 import sherlock
 import unittest
-
-from mock import Mock
+from unittest.mock import Mock
 
 # import reload in Python 3
 try:

--- a/tests/test_sherlock.py
+++ b/tests/test_sherlock.py
@@ -5,9 +5,10 @@
 import etcd
 import sherlock
 import unittest
+from unittest.mock import Mock
+
 
 from sherlock import _Configuration
-from mock import Mock
 
 # import reload in Python 3
 try:


### PR DESCRIPTION
- `nose` is no longer maintained.
- `nose` is broken on Python 3.10.
- `pytest` is much more widely used and almost the defacto testing framework.
- Allows easy use of `pytest-cov` and therefore easier use of CodeCov

This is stacked on top of #49