### PR TITLE
Add python 3.12 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,18 +21,17 @@ classifiers = [
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 packages = [
     { include = "sherlock" },
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.9"
 
 filelock = { version = "^3.7.1", optional = true }
 kubernetes = { version = "^24.2.0", optional = true }

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
 envlist =
-    py37,
-    py38,
     py39,
     py310,
-    py311
+    py311,
+    py312
 isolated_build = true
 
 [testenv]
@@ -66,11 +65,10 @@ healthcheck_start_period = 0
 
 [gh-actions]
 python =
-    3.7: py37
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
 fail_on_no_env = True
 
 [flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ docker =
     redis
     memcached
     kubernetes
-whitelist_externals = poetry
+allowlist_externals = poetry
 
 [tox:.package]
 basepython = python3


### PR DESCRIPTION
Python 3.12 was released a while ago and is now used mainly in Ubuntu Noble.

Also remove support for Python <= 3.8 because these are already in EOL status.